### PR TITLE
Docs: example README updates — inbox (server) terminology and dashboard links

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -29,7 +29,7 @@ The tests read configuration from environment variables. You can export these di
 | Variable | Required | Used by | Description |
 | --- | --- | --- | --- |
 | `MAILOSAUR_API_KEY` | Yes | All tests | Your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of the Mailosaur Dashboard. |
-| `MAILOSAUR_SERVER_ID` | Yes | `passwordReset.cy.js`, `otpEmail.cy.js`, `otpSms.cy.js` | The ID of the Mailosaur server to test against. |
+| `MAILOSAUR_SERVER_ID` | Yes | `passwordReset.cy.js`, `otpEmail.cy.js`, `otpSms.cy.js` | The ID of the Mailosaur inbox (server) to test against. |
 | `MAILOSAUR_PHONE_NUMBER` | Only for `otpSms.cy.js` | `otpSms.cy.js` | A Mailosaur phone number reserved on your account. Requires [SMS testing](https://mailosaur.com/app/sms) to be enabled. |
 
 Example:

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -16,6 +16,29 @@ We also have specific documentation for [Cypress](https://mailosaur.com/docs/fra
 
 As well as documentation for [Node.js](https://mailosaur.com/docs/languages/nodejs).
 
+## Setup
+
+Install dependencies:
+
+```
+npm install
+```
+
+The tests read configuration from environment variables. You can export these directly, or place them in a `.env` file at the project root (this is loaded automatically by `cypress.config.js` via `dotenv`).
+
+| Variable | Required | Used by | Description |
+| --- | --- | --- | --- |
+| `MAILOSAUR_API_KEY` | Yes | All tests | Your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of the Mailosaur Dashboard. |
+| `MAILOSAUR_SERVER_ID` | Yes | `passwordReset.cy.js`, `otpEmail.cy.js`, `otpSms.cy.js` | The ID of the Mailosaur server to test against. |
+| `MAILOSAUR_PHONE_NUMBER` | Only for `otpSms.cy.js` | `otpSms.cy.js` | A Mailosaur phone number reserved on your account. Requires [SMS testing](https://mailosaur.com/app/sms) to be enabled. |
+
+Example:
+
+```sh
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+```
+
 ## Running Tests
 
 You can run all the example tests included in this project using `npm`:
@@ -72,7 +95,7 @@ npx cypress run --spec "cypress/e2e/mailosaur/otpSms.cy.js"
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (**NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` environment variable to your dedicated Mailosaur phone number — see [Setup](#setup) above.)
 
 2. Grabs the one-time password (OTP).
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -28,7 +28,7 @@ The tests read configuration from environment variables. You can export these di
 
 | Variable | Required | Used by | Description |
 | --- | --- | --- | --- |
-| `MAILOSAUR_API_KEY` | Yes | All tests | Your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of the Mailosaur Dashboard. |
+| `MAILOSAUR_API_KEY` | Yes | All tests | Your Mailosaur API key. [Find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). |
 | `MAILOSAUR_SERVER_ID` | Yes | `passwordReset.cy.js`, `otpEmail.cy.js`, `otpSms.cy.js` | The ID of the Mailosaur inbox (server) to test against. |
 | `MAILOSAUR_PHONE_NUMBER` | Only for `otpSms.cy.js` | `otpSms.cy.js` | A Mailosaur phone number reserved on your account. Requires [SMS testing](https://mailosaur.com/app/sms) to be enabled. |
 

--- a/go/README.md
+++ b/go/README.md
@@ -14,6 +14,20 @@ Documentation can be found on [Mailosaur's site](https://mailosaur.com/docs).
 
 We also have specific documentation for [Go](https://mailosaur.com/docs/languages/go).
 
+## Setup
+
+Before running the tests, export the following environment variables (or place them in a `.env` file — these examples use [godotenv](https://github.com/joho/godotenv) to load it automatically):
+
+```sh
+export MAILOSAUR_API_KEY=your-api-key       # required by all tests
+export MAILOSAUR_SERVER_ID=your-server-id   # required by password reset, email OTP, and SMS OTP tests
+export MAILOSAUR_PHONE_NUMBER=4471235554444 # required by the SMS OTP test only
+```
+
+You can find your API key and server ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+
+The Mailosaur Go client reads `MAILOSAUR_API_KEY` from the environment when constructed with no arguments (`mailosaur.New()`).
+
 ## Running Tests
 
 You can run all the example tests included in this project using `go`:
@@ -23,7 +37,7 @@ go test -v
 ```
 
 > [!NOTE]  
-> All tests are skipped by default as configuration is required for them to run.
+> All tests are skipped by default as configuration is required for them to run. Remove the `t.Skip(...)` line in each test once you've completed the setup above.
 
 # What's Included
 
@@ -70,7 +84,7 @@ go test -run TestOtpSms -v
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (**NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` environment variable to your dedicated Mailosaur phone number — see the [Setup](#setup) section above.)
 
 2. Grabs the one-time password (OTP).
 

--- a/go/README.md
+++ b/go/README.md
@@ -24,7 +24,7 @@ export MAILOSAUR_SERVER_ID=your-server-id   # required by password reset, email 
 export MAILOSAUR_PHONE_NUMBER=4471235554444 # required by the SMS OTP test only
 ```
 
-You can find your API key and server ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can find your API key and inbox (server) ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
 
 The Mailosaur Go client reads `MAILOSAUR_API_KEY` from the environment when constructed with no arguments (`mailosaur.New()`).
 

--- a/go/README.md
+++ b/go/README.md
@@ -24,7 +24,7 @@ export MAILOSAUR_SERVER_ID=your-server-id   # required by password reset, email 
 export MAILOSAUR_PHONE_NUMBER=4471235554444 # required by the SMS OTP test only
 ```
 
-You can find your API key and inbox (server) ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`).
 
 The Mailosaur Go client reads `MAILOSAUR_API_KEY` from the environment when constructed with no arguments (`mailosaur.New()`).
 

--- a/go/otp_authenticator_test.go
+++ b/go/otp_authenticator_test.go
@@ -7,7 +7,6 @@ package mailosaurExample
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/joho/godotenv"
@@ -18,11 +17,9 @@ func TestOtpAuthenticator(t *testing.T) {
   t.Skip("reason")
 
   godotenv.Load()
-  
-  apiKey := os.Getenv("MAILOSAUR_API_KEY")
 
-  // Instantiate Mailosaur client with api key
-  m := mailosaur.New(apiKey)
+  // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+  m := mailosaur.New()
 
 	/**
    * This is a base32-encoded shared secret.

--- a/go/otp_email_test.go
+++ b/go/otp_email_test.go
@@ -13,12 +13,11 @@ func TestOtpEmail(t *testing.T) {
   t.Skip("reason")
 
   godotenv.Load()
-  
-  apiKey := os.Getenv("MAILOSAUR_API_KEY")
+
   serverId := os.Getenv("MAILOSAUR_SERVER_ID")
 
-  // Instantiate Mailosaur client with api key
-  m := mailosaur.New(apiKey)
+  // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+  m := mailosaur.New()
 
   // Test email address (this uses a catch-all pattern)
   emailAddress := fmt.Sprintf("test-email@%s.mailosaur.net", serverId)

--- a/go/otp_sms_test.go
+++ b/go/otp_sms_test.go
@@ -18,15 +18,14 @@ func TestOtpSms(t *testing.T) {
   t.Skip("reason")
 
   godotenv.Load()
-  
-  apiKey := os.Getenv("MAILOSAUR_API_KEY")
+
   serverId := os.Getenv("MAILOSAUR_SERVER_ID")
 
-  // Add your mailosaur servers number to this variable
+  // Add your Mailosaur server's phone number to this variable
   phoneNumber := os.Getenv("MAILOSAUR_PHONE_NUMBER")
 
-  // Instantiate Mailosaur client with api key
-  m := mailosaur.New(apiKey)
+  // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+  m := mailosaur.New()
 
   // 1 - Perform an action that sends an otp SMS message to your number
   // https://mailosaur.com/docs/sms-testing

--- a/go/password_reset_test.go
+++ b/go/password_reset_test.go
@@ -13,12 +13,11 @@ func TestPasswordReset(t *testing.T) {
   t.Skip("reason")
 
   godotenv.Load()
-  
-  apiKey := os.Getenv("MAILOSAUR_API_KEY")
+
   serverId := os.Getenv("MAILOSAUR_SERVER_ID")
 
-  // Instantiate Mailosaur client with api key
-  m := mailosaur.New(apiKey)
+  // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+  m := mailosaur.New()
 
   // Test email address (this uses a catch-all pattern)
   emailAddress := fmt.Sprintf("test-email@%s.mailosaur.net", serverId)

--- a/php/README.md
+++ b/php/README.md
@@ -4,7 +4,7 @@
 </a>
 </p>
 
-# Getting Started
+# Mailosaur PHP examples
 
 Visit [Mailosaur's website](https://mailosaur.com) to learn more about Mailosaur, create your own free trial and get started with email and SMS test automation.
 
@@ -12,28 +12,55 @@ Visit [Mailosaur's website](https://mailosaur.com) to learn more about Mailosaur
 
 Documentation can be found on [Mailosaur's site](https://mailosaur.com/docs).
 
-We also have specific documentation for [PHP](https://mailosaur.com/docs/languages/php).
+We also have specific documentation for [PHP](https://mailosaur.com/docs/languages/php/).
 
-## Running Tests
+## Setup
+
+The example tests read configuration from environment variables. Before running them, export the variables your chosen test requires:
+
+```sh
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+# Only required for the SMS test
+export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
+```
+
+You can find your API key and server ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The phone number is only needed for the SMS example — see [Setup a phone number](https://mailosaur.com/app/sms).
+
+Alternatively, you can place the same variables in a `.env` file at the project root. The bootstrap file uses [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv) to load them if present:
+
+```env
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=your-server-id
+MAILOSAUR_PHONE_NUMBER=your-mailosaur-phone-number
+```
+
+Install dependencies before running the tests:
+
+```sh
+composer install
+```
+
+## Running tests
 
 You can run all the example tests included in this project using `composer`:
 
-```
+```sh
 composer run test
 ```
 
-> [!NOTE]  
-> All tests are skipped by default as configuration is required for them to run.
+> [!NOTE]
+> All tests are skipped by default as configuration is required for them to run. Open each test file and remove the `$this->markTestSkipped('Reason');` line for the scenario you want to execute.
 
-# What's Included
+# What's included
 
-This project includes examples for many common test scenarios:
+This project includes examples for many common test scenarios.
 
-## Reset a password using email - `PasswordResetTests.php`
+## Reset a password using email — `PasswordResetTests.php`
 
 Shows you how to perform an automated test for a password reset workflow:
 
-```
+```sh
 vendor/bin/phpunit --filter PasswordResetTests
 ```
 
@@ -51,14 +78,14 @@ When you run the test, it:
 
 3. Logs the password reset link. Once you have this working, you would change this to an assertion or navigate to it.
 
-## Multi-Factor Authentication (MFA) via SMS - `OtpSmsTests.php`
+## Multi-Factor Authentication (MFA) via SMS — `OtpSmsTests.php`
 
-> [!NOTE]  
-> **Setup Required -** [enable SMS testing](https://mailosaur.com/app/sms), and setup a phone number, within your Mailosaur account.
+> [!NOTE]
+> **Setup Required —** [enable SMS testing](https://mailosaur.com/app/sms) and set up a phone number within your Mailosaur account. Then set `MAILOSAUR_PHONE_NUMBER` (see [Setup](#setup)).
 
 Shows you how to test two-step verification workflows that use text messages:
 
-```
+```sh
 vendor/bin/phpunit --filter OtpSmsTests
 ```
 
@@ -70,17 +97,17 @@ vendor/bin/phpunit --filter OtpSmsTests
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number.
 
 2. Grabs the one-time password (OTP).
 
 3. Logs the OTP value. Once you have this working, you would change this to an assertion.
 
-## Multi-Factor Authentication (MFA) via Email - `OtpEmailTests.php`
+## Multi-Factor Authentication (MFA) via Email — `OtpEmailTests.php`
 
 Shows you how to perform an automated test for a workflow that sends a one-time password (OTP) via email:
 
-```
+```sh
 vendor/bin/phpunit --filter OtpEmailTests
 ```
 
@@ -100,14 +127,14 @@ When you run the test, it:
 
 4. Logs the OTP value. Once you have this working, you would change this to an assertion.
 
-## Multi-Factor Authentication (MFA) via App - `OtpAuthenticatorTests.php`
+## Multi-Factor Authentication (MFA) via App — `OtpAuthenticatorTests.php`
 
-> [!NOTE]  
-> **Setup Required -** [enable Mailosaur Authenticator](https://mailosaur.com/app/authenticator) within your Mailosaur account.
+> [!NOTE]
+> **Setup Required —** [enable Mailosaur Authenticator](https://mailosaur.com/app/authenticator) within your Mailosaur account.
 
 Shows you how to test a workflow that uses app-based two-step verification (e.g. Google Authenticator, Auth0, etc.):
 
-```
+```sh
 vendor/bin/phpunit --filter OtpAuthenticatorTests
 ```
 

--- a/php/README.md
+++ b/php/README.md
@@ -25,7 +25,7 @@ export MAILOSAUR_SERVER_ID='your-server-id'
 export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
 ```
 
-You can find your API key and server ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The phone number is only needed for the SMS example — see [Setup a phone number](https://mailosaur.com/app/sms).
+You can find your API key and inbox (server) ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The phone number is only needed for the SMS example — see [Setup a phone number](https://mailosaur.com/app/sms).
 
 Alternatively, you can place the same variables in a `.env` file at the project root. The bootstrap file uses [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv) to load them if present:
 

--- a/php/README.md
+++ b/php/README.md
@@ -25,7 +25,7 @@ export MAILOSAUR_SERVER_ID='your-server-id'
 export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
 ```
 
-You can find your API key and inbox (server) ID on the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The phone number is only needed for the SMS example — see [Setup a phone number](https://mailosaur.com/app/sms).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`). The phone number is only needed for the SMS example — see [Setup a phone number](https://mailosaur.com/app/sms).
 
 Alternatively, you can place the same variables in a `.env` file at the project root. The bootstrap file uses [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv) to load them if present:
 

--- a/php/tests/OtpAuthenticatorTests.php
+++ b/php/tests/OtpAuthenticatorTests.php
@@ -18,10 +18,8 @@ class OtpAuthenticatorTests extends \PHPUnit\Framework\TestCase
   
   public static function setUpBeforeClass(): void
   {
-    $apiKey = $_ENV['MAILOSAUR_API_KEY'];
-    
-    // Instantiate Mailosaur client with api key
-    self::$client = new MailosaurClient($apiKey);
+    // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+    self::$client = new MailosaurClient();
   }
   
   /** @test */

--- a/php/tests/OtpEmailTests.php
+++ b/php/tests/OtpEmailTests.php
@@ -16,11 +16,10 @@ class OtpEmailTests extends \PHPUnit\Framework\TestCase
   
   public static function setUpBeforeClass(): void
   {
-    $apiKey = $_ENV['MAILOSAUR_API_KEY'];
     self::$server = $_ENV['MAILOSAUR_SERVER_ID'];
 
-    // Instantiate Mailosaur client with api key
-    self::$client = new MailosaurClient($apiKey);
+    // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+    self::$client = new MailosaurClient();
   }
 
   /** @test */

--- a/php/tests/OtpSmsTests.php
+++ b/php/tests/OtpSmsTests.php
@@ -25,14 +25,13 @@ class OtpSmsTests extends \PHPUnit\Framework\TestCase
   
   public static function setUpBeforeClass(): void
   {
-    $apiKey = $_ENV['MAILOSAUR_API_KEY'];
     self::$server = $_ENV['MAILOSAUR_SERVER_ID'];
 
-    // Add your mailosaur servers number to this variable
+    // Add your Mailosaur server's phone number to this variable
     self::$phoneNumber = $_ENV['MAILOSAUR_PHONE_NUMBER'];
-    
-    // Instantiate Mailosaur client with api key
-    self::$client = new MailosaurClient($apiKey);
+
+    // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+    self::$client = new MailosaurClient();
   }
   
   /** @test */

--- a/php/tests/PasswordResetTests.php
+++ b/php/tests/PasswordResetTests.php
@@ -16,11 +16,10 @@ class PasswordResetTests extends \PHPUnit\Framework\TestCase
   
   public static function setUpBeforeClass(): void
   {
-    $apiKey = $_ENV['MAILOSAUR_API_KEY'];
     self::$server = $_ENV['MAILOSAUR_SERVER_ID'];
 
-    // Instantiate Mailosaur client with api key
-    self::$client = new MailosaurClient($apiKey);
+    // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+    self::$client = new MailosaurClient();
   }
 
   /** @test */

--- a/php/tests/bootstrap.php
+++ b/php/tests/bootstrap.php
@@ -2,5 +2,5 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$dotenv = Dotenv\Dotenv::createImmutable('.');
-$dotenv->load();
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable('.');
+$dotenv->safeLoad();

--- a/playwright/dotnet/OtpAuthenticatorTests.cs
+++ b/playwright/dotnet/OtpAuthenticatorTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using Mailosaur;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
@@ -18,16 +17,11 @@ public class OtpAuthenticatorTests : PageTest
 {
     [Test]
     public void GenerateOneTimePasscode()
-    {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+    {
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         /**
          * This is a base32-encoded shared secret.

--- a/playwright/dotnet/OtpEmailTests.cs
+++ b/playwright/dotnet/OtpEmailTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
@@ -15,16 +14,12 @@ public class OtpEmailTests : PageTest
     [Test]
     public async Task RetrieveOneTimePasscodeFromEmail()
     {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // Random test email address (this uses a catch-all pattern)
         var randomString = Guid.NewGuid().ToString();

--- a/playwright/dotnet/OtpSmsTests.cs
+++ b/playwright/dotnet/OtpSmsTests.cs
@@ -6,7 +6,6 @@
 using System;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
 
@@ -20,19 +19,15 @@ public class OtpSmsTests : PageTest
     [Test]
     public void RetrieveOneTimePasscodeFromSms()
     {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
         // Add your mailosaur servers number to this variable
-        var phoneNumber = configuration["Secrets:MailosaurPhoneNumber"];
+        var phoneNumber = Environment.GetEnvironmentVariable("MAILOSAUR_PHONE_NUMBER");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // 1 - Perform an action that sends an otp SMS message to your number
         // https://mailosaur.com/docs/sms-testing

--- a/playwright/dotnet/PasswordResetTests.cs
+++ b/playwright/dotnet/PasswordResetTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using Microsoft.Playwright.NUnit;
 using NUnit.Framework;
@@ -15,16 +14,12 @@ public class PasswordResetTests : PageTest
     [Test]
     public async Task PerformPasswordReset()
     {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // Random test email address (this uses a catch-all pattern)
         var randomString = Guid.NewGuid().ToString();

--- a/playwright/dotnet/README.md
+++ b/playwright/dotnet/README.md
@@ -32,7 +32,7 @@ MAILOSAUR_PHONE_NUMBER=
 
 Alternatively, export the same variables in your shell instead of using a `.env` file.
 
-You can find your API key, Server ID, and any reserved phone numbers in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`), and any reserved phone numbers are listed there too.
 
 ## Running Tests
 

--- a/playwright/dotnet/README.md
+++ b/playwright/dotnet/README.md
@@ -16,6 +16,24 @@ We also have specific documentation for [Playwright](https://mailosaur.com/docs/
 
 As well as documentation for [.NET](https://mailosaur.com/docs/languages/dotnet).
 
+## Setup
+
+The tests load configuration from a `.env` file in this directory (or from your shell environment) using [DotNetEnv](https://github.com/tonerdo/dotnet-env). Create a `.env` file with the following keys:
+
+```
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=your-server-id
+MAILOSAUR_PHONE_NUMBER=
+```
+
+- `MAILOSAUR_API_KEY` — read automatically by `MailosaurClient`.
+- `MAILOSAUR_SERVER_ID` — used by the password reset and email OTP tests.
+- `MAILOSAUR_PHONE_NUMBER` — your dedicated Mailosaur phone number, used only by the SMS OTP test.
+
+Alternatively, export the same variables in your shell instead of using a `.env` file.
+
+You can find your API key, Server ID, and any reserved phone numbers in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+
 ## Running Tests
 
 You can run all the example tests included in this project using `dotnet`:
@@ -24,7 +42,7 @@ You can run all the example tests included in this project using `dotnet`:
 dotnet test
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Where a test depends on a feature that may not yet be enabled on your account, the test is skipped by default.
 
 # What's Included
@@ -72,7 +90,7 @@ dotnet test --filter RetrieveOneTimePasscodeFromSms
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MailosaurPhoneNumber` variable inside the `appsettings.Testing.json` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (**NOTE:** You must first set `MAILOSAUR_PHONE_NUMBER` to your dedicated Mailosaur phone number — see the [Setup](#setup) section above.)
 
 2. Grabs the one-time password (OTP).
 

--- a/playwright/dotnet/mailosaur-example.csproj
+++ b/playwright/dotnet/mailosaur-example.csproj
@@ -8,15 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="mailosaur" Version="8.8.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.44.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="appsettings.Testing.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/playwright/nodejs/README.md
+++ b/playwright/nodejs/README.md
@@ -12,9 +12,31 @@ Visit [Mailosaur's website](https://mailosaur.com) to learn more about Mailosaur
 
 Documentation can be found on [Mailosaur's site](https://mailosaur.com/docs).
 
-We also have specific documentation for [Playwright](https://mailosaur.com/docs/frameworks-and-tools/playwright) on [email testing](https://mailosaur.com/docs/email-testing/playwright) and [SMS testing](https://mailosaur.com/docs/sms-testing/playwright).
+We also have specific documentation for [Playwright](https://mailosaur.com/docs/frameworks-and-tools/playwright) on [email testing](https://mailosaur.com/docs/email-testing/playwright) and [SMS testing](https://mailosaur.com/docs/sms-testing/playwright), as well as documentation for [Node.js](https://mailosaur.com/docs/languages/nodejs).
 
-As well as documentation for [Node.js](https://mailosaur.com/docs/languages/nodejs).
+## Setup
+
+Install the project dependencies:
+
+```
+npm install
+```
+
+The tests read configuration from environment variables. You can either `export` them in your shell or create a `.env` file in this directory (loaded automatically via `dotenv`).
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `MAILOSAUR_API_KEY` | All tests | Your Mailosaur API key. The Mailosaur client reads this automatically when instantiated with no arguments. [Find your key](https://mailosaur.com/app/keys). |
+| `MAILOSAUR_SERVER_ID` | `passwordReset.spec.js`, `otpEmail.spec.js`, `otpSms.spec.js` | The ID of the Mailosaur server to use. [Find your server ID](https://mailosaur.com/app/servers). |
+| `MAILOSAUR_PHONE_NUMBER` | `otpSms.spec.js` | A phone number reserved on your Mailosaur account. Required only for the SMS test. |
+
+Example:
+
+```
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
+```
 
 ## Running Tests
 
@@ -72,7 +94,7 @@ npx playwright test otpSms.spec.js
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` environment variable to your dedicated Mailosaur phone number — see [Setup](#setup) above.)
 
 2. Grabs the one-time password (OTP).
 

--- a/playwright/nodejs/README.md
+++ b/playwright/nodejs/README.md
@@ -27,7 +27,7 @@ The tests read configuration from environment variables. You can either `export`
 | Variable | Used by | Description |
 | --- | --- | --- |
 | `MAILOSAUR_API_KEY` | All tests | Your Mailosaur API key. The Mailosaur client reads this automatically when instantiated with no arguments. [Find your key](https://mailosaur.com/app/keys). |
-| `MAILOSAUR_SERVER_ID` | `passwordReset.spec.js`, `otpEmail.spec.js`, `otpSms.spec.js` | The ID of the Mailosaur server to use. [Find your server ID](https://mailosaur.com/app/servers). |
+| `MAILOSAUR_SERVER_ID` | `passwordReset.spec.js`, `otpEmail.spec.js`, `otpSms.spec.js` | The ID of the Mailosaur inbox (server) to use. [Find your inbox (server) ID](https://mailosaur.com/app/servers). |
 | `MAILOSAUR_PHONE_NUMBER` | `otpSms.spec.js` | A phone number reserved on your Mailosaur account. Required only for the SMS test. |
 
 Example:

--- a/playwright/nodejs/tests/otpAuthenticator.spec.js
+++ b/playwright/nodejs/tests/otpAuthenticator.spec.js
@@ -8,8 +8,8 @@ require('dotenv').config();
 const MailosaurClient = require('mailosaur');
 const { skip, test } = require('@playwright/test');
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from env)
+const mailosaur = new MailosaurClient();
 
 test.describe('One time passcode - Authenticator', () => {
   skip('Generate one time passcode', async () => {

--- a/playwright/nodejs/tests/otpEmail.spec.js
+++ b/playwright/nodejs/tests/otpEmail.spec.js
@@ -3,8 +3,8 @@ require('dotenv').config();
 const MailosaurClient = require('mailosaur');
 const { expect, test } = require('@playwright/test');
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from env)
+const mailosaur = new MailosaurClient();
 const serverId = process.env.MAILOSAUR_SERVER_ID;
 
 test.describe('One time passcode - Email', () => {

--- a/playwright/nodejs/tests/otpSms.spec.js
+++ b/playwright/nodejs/tests/otpSms.spec.js
@@ -8,8 +8,8 @@ require('dotenv').config();
 const MailosaurClient = require('mailosaur');
 const { skip, test } = require('@playwright/test');
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from env)
+const mailosaur = new MailosaurClient();
 const serverId = process.env.MAILOSAUR_SERVER_ID;
 
 // Add your mailosaur servers number to this variable

--- a/playwright/nodejs/tests/passwordReset.spec.js
+++ b/playwright/nodejs/tests/passwordReset.spec.js
@@ -3,8 +3,8 @@ require('dotenv').config();
 const MailosaurClient = require('mailosaur');
 const { test, expect } = require('@playwright/test');
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from env)
+const mailosaur = new MailosaurClient();
 const serverId = process.env.MAILOSAUR_SERVER_ID;
 
 test.describe('Password reset', () => {

--- a/robotframework/README.md
+++ b/robotframework/README.md
@@ -27,7 +27,7 @@ As well as documentation for [Python](https://mailosaur.com/docs/languages/pytho
 2. Set the following environment variables. You can either `export` them directly, or place them in a `.env` file in this directory (the test library uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load them automatically):
 
    - `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of your Mailosaur Dashboard.
-   - `MAILOSAUR_SERVER_ID` — the ID of the server (project) to test against.
+   - `MAILOSAUR_SERVER_ID` — the ID of the inbox (server), which acts like a project, to test against.
    - `MAILOSAUR_PHONE_NUMBER` — only required if you plan to run the SMS test (`otp_sms.robot`). Set to a phone number reserved within your Mailosaur account.
 
    The Python library file `tests/script_keywords.py` reads these variables, and the Robot Framework resource file `tests/resource.robot` imports it as a library along with `SeleniumLibrary`.

--- a/robotframework/README.md
+++ b/robotframework/README.md
@@ -16,6 +16,22 @@ We also have specific documentation for [Robot Framework](https://mailosaur.com/
 
 As well as documentation for [Python](https://mailosaur.com/docs/languages/python).
 
+## Setup
+
+1. Install the project dependencies:
+
+   ```
+   pip install -r requirements.txt
+   ```
+
+2. Set the following environment variables. You can either `export` them directly, or place them in a `.env` file in this directory (the test library uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load them automatically):
+
+   - `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of your Mailosaur Dashboard.
+   - `MAILOSAUR_SERVER_ID` — the ID of the server (project) to test against.
+   - `MAILOSAUR_PHONE_NUMBER` — only required if you plan to run the SMS test (`otp_sms.robot`). Set to a phone number reserved within your Mailosaur account.
+
+   The Python library file `tests/script_keywords.py` reads these variables, and the Robot Framework resource file `tests/resource.robot` imports it as a library along with `SeleniumLibrary`.
+
 ## Running Tests
 
 You can run all the example tests included in this project using `robot`:
@@ -24,7 +40,7 @@ You can run all the example tests included in this project using `robot`:
 robot tests
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Where a test depends on a feature that may not yet be enabled on your account, the test is skipped by default.
 
 # What's Included
@@ -72,7 +88,7 @@ robot -t "Otp Sms"  tests/otp_sms.robot
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` environment variable (or add it to your `.env` file) to your dedicated Mailosaur phone number.)
 
 2. Grabs the one-time password (OTP).
 

--- a/robotframework/README.md
+++ b/robotframework/README.md
@@ -26,7 +26,7 @@ As well as documentation for [Python](https://mailosaur.com/docs/languages/pytho
 
 2. Set the following environment variables. You can either `export` them directly, or place them in a `.env` file in this directory (the test library uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load them automatically):
 
-   - `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it on the [API tab](https://mailosaur.com/app/project/api) of your Mailosaur Dashboard.
+   - `MAILOSAUR_API_KEY` — your Mailosaur API key. [Find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys).
    - `MAILOSAUR_SERVER_ID` — the ID of the inbox (server), which acts like a project, to test against.
    - `MAILOSAUR_PHONE_NUMBER` — only required if you plan to run the SMS test (`otp_sms.robot`). Set to a phone number reserved within your Mailosaur account.
 

--- a/robotframework/tests/script_keywords.py
+++ b/robotframework/tests/script_keywords.py
@@ -13,13 +13,13 @@ load_dotenv()
 class script_keywords:
 
     def __init__(self):
-        api_key = os.getenv('MAILOSAUR_API_KEY')
         server_id = os.getenv('MAILOSAUR_SERVER_ID')
         phone_number = os.getenv('MAILOSAUR_PHONE_NUMBER')
 
-        # Instantiate Mailosaur client with api key
-        self.mailosaur = MailosaurClient(api_key)
-        
+        # Instantiate Mailosaur client; the API key is read automatically
+        # from the MAILOSAUR_API_KEY environment variable.
+        self.mailosaur = MailosaurClient()
+
         self.server_id = server_id
         self.phone_number = phone_number
 

--- a/selenium/dotnet/OtpAuthenticatorTests.cs
+++ b/selenium/dotnet/OtpAuthenticatorTests.cs
@@ -6,7 +6,6 @@
 using System;
 using Xunit;
 using Mailosaur;
-using Microsoft.Extensions.Configuration;
 
 namespace mailosaur_example;
 
@@ -14,16 +13,11 @@ public class OtpAuthenticatorTests()
 {
     [Fact (Skip = "Reason")]
     public void GenerateOneTimePasscode()
-    {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+    {
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         /**
          * This is a base32-encoded shared secret.

--- a/selenium/dotnet/OtpEmailTests.cs
+++ b/selenium/dotnet/OtpEmailTests.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 
@@ -17,16 +16,12 @@ public class OtpEmailTests()
         options.AddArgument("--headless=new");
         IWebDriver browser = new ChromeDriver(options);
 
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // Random test email address (this uses a catch-all pattern)
         var randomString = Guid.NewGuid().ToString();

--- a/selenium/dotnet/OtpSmsTests.cs
+++ b/selenium/dotnet/OtpSmsTests.cs
@@ -7,7 +7,6 @@ using System;
 using Xunit;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 
 namespace mailosaur_example;
 
@@ -16,19 +15,15 @@ public class OtpSmsTests()
     [Fact (Skip = "Reason")]
     public void RetrieveOneTimePasscodeFromSms()
     {            
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
         // Add your mailosaur servers number to this variable
-        var phoneNumber = configuration["Secrets:MailosaurPhoneNumber"];
+        var phoneNumber = Environment.GetEnvironmentVariable("MAILOSAUR_PHONE_NUMBER");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // 1 - Perform an action that sends an otp SMS message to your number
         // https://mailosaur.com/docs/sms-testing

--- a/selenium/dotnet/PasswordResetTests.cs
+++ b/selenium/dotnet/PasswordResetTests.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using Mailosaur;
 using Mailosaur.Models;
-using Microsoft.Extensions.Configuration;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 
@@ -17,16 +16,12 @@ public class PasswordResetTests()
         options.AddArgument("--headless=new");
         IWebDriver browser = new ChromeDriver(options);
 
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Testing.json")
-            .Build();
+        DotNetEnv.Env.TraversePath().Load();
 
-        // Move this to an appropriate secrets manager!
-        var apiKey = configuration["Secrets:MailosaurApiKey"];
-        var serverId = configuration["Secrets:MailosaurServerId"];
+        var serverId = Environment.GetEnvironmentVariable("MAILOSAUR_SERVER_ID");
 
-        // Instantiate Mailosaur client with api key
-        var mailosaur = new MailosaurClient(apiKey);
+        // Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+        var mailosaur = new MailosaurClient();
 
         // Random test email address (this uses a catch-all pattern)
         var randomString = Guid.NewGuid().ToString();

--- a/selenium/dotnet/README.md
+++ b/selenium/dotnet/README.md
@@ -30,7 +30,7 @@ MAILOSAUR_PHONE_NUMBER=
 
 Alternatively, export the same variables in your shell instead of using a `.env` file.
 
-You can find your API key, Server ID, and any reserved phone numbers in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`), and any reserved phone numbers are listed there too.
 
 ## Running Tests
 

--- a/selenium/dotnet/README.md
+++ b/selenium/dotnet/README.md
@@ -12,9 +12,25 @@ Visit [Mailosaur's website](https://mailosaur.com) to learn more about Mailosaur
 
 Documentation can be found on [Mailosaur's site](https://mailosaur.com/docs).
 
-We also have specific documentation for [Selenium](https://mailosaur.com/docs/frameworks-and-tools/selenium).
+We also have specific documentation for [Selenium](https://mailosaur.com/docs/frameworks-and-tools/selenium), as well as for [.NET](https://mailosaur.com/docs/languages/dotnet).
 
-As well as documentation for [.NET](https://mailosaur.com/docs/languages/dotnet).
+## Setup
+
+The tests load configuration from a `.env` file in this directory (or from your shell environment) using [DotNetEnv](https://github.com/tonerdo/dotnet-env). Create a `.env` file with the following keys:
+
+```
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=your-server-id
+MAILOSAUR_PHONE_NUMBER=
+```
+
+- `MAILOSAUR_API_KEY` — read automatically by `MailosaurClient`.
+- `MAILOSAUR_SERVER_ID` — used by the password reset and email OTP tests.
+- `MAILOSAUR_PHONE_NUMBER` — your dedicated Mailosaur phone number, used only by the SMS OTP test.
+
+Alternatively, export the same variables in your shell instead of using a `.env` file.
+
+You can find your API key, Server ID, and any reserved phone numbers in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
 
 ## Running Tests
 
@@ -24,7 +40,7 @@ You can run all the example tests included in this project using `dotnet`:
 dotnet test
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Where a test depends on a feature that may not yet be enabled on your account, the test is skipped by default.
 
 # What's Included
@@ -55,7 +71,7 @@ dotnet test --filter PerformPasswordReset
 
 ## Multi-Factor Authentication (MFA) via SMS - `OtpSmsTests.cs`
 
-> [!NOTE]  
+> [!NOTE]
 > **Setup Required -** [enable SMS testing](https://mailosaur.com/app/sms), and setup a phone number, within your Mailosaur account.
 
 Shows you how to test two-step verification workflows that use text messages:
@@ -72,7 +88,7 @@ dotnet test --filter RetrieveOneTimePasscodeFromSms
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MailosaurPhoneNumber` variable inside the `appsettings.Testing.json` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (**NOTE:** You must first set `MAILOSAUR_PHONE_NUMBER` to your dedicated Mailosaur phone number — see the [Setup](#setup) section above.)
 
 2. Grabs the one-time password (OTP).
 
@@ -102,7 +118,7 @@ dotnet test --filter RetrieveOneTimePasscodeFromEmail
 
 ## Multi-Factor Authentication (MFA) via App - `OtpAuthenticatorTests.cs`
 
-> [!NOTE]  
+> [!NOTE]
 > **Setup Required -** [enable Mailosaur Authenticator](https://mailosaur.com/app/authenticator) within your Mailosaur account.
 
 Shows you how to test a workflow that uses app-based two-step verification (e.g. Google Authenticator, Auth0, etc.):

--- a/selenium/dotnet/mailosaur-example.csproj
+++ b/selenium/dotnet/mailosaur-example.csproj
@@ -8,9 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="mailosaur" Version="8.8.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
@@ -21,10 +20,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="appsettings.Testing.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/selenium/java/README.md
+++ b/selenium/java/README.md
@@ -16,6 +16,31 @@ We also have specific documentation for [Selenium](https://mailosaur.com/docs/fr
 
 As well as documentation for [Java](https://mailosaur.com/docs/languages/java).
 
+## Setup
+
+Before running the tests, export the following environment variables:
+
+```sh
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+```
+
+If you plan to run the SMS test (`OtpSmsTest`), also export:
+
+```sh
+export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
+```
+
+Alternatively, create a `.env` file in the project root with the same keys — the tests load it via [dotenv-java](https://github.com/cdimascio/dotenv-java):
+
+```
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=your-server-id
+MAILOSAUR_PHONE_NUMBER=
+```
+
+You can find your API key and Server ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+
 ## Running Tests
 
 You can run all the example tests included in this project using `mvn`:
@@ -72,7 +97,7 @@ mvn test -Dtest=OtpSmsTest
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `mailosaurPhoneNumber` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** You must first export the `MAILOSAUR_PHONE_NUMBER` environment variable, set to your dedicated Mailosaur phone number.)
 
 2. Grabs the one-time password (OTP).
 

--- a/selenium/java/README.md
+++ b/selenium/java/README.md
@@ -39,7 +39,7 @@ MAILOSAUR_SERVER_ID=your-server-id
 MAILOSAUR_PHONE_NUMBER=
 ```
 
-You can find your API key and Server ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`).
 
 ## Running Tests
 

--- a/selenium/java/src/test/java/demo/OtpAuthenticatorTest.java
+++ b/selenium/java/src/test/java/demo/OtpAuthenticatorTest.java
@@ -16,12 +16,9 @@ import java.io.IOException;
 public class OtpAuthenticatorTest {
   @Ignore("Reason")
   @Test public void retrieveOneTimePasscode() throws IOException, MailosaurException {
-    Dotenv dotenv = Dotenv.load();
+    Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
 
-    String apiKey = dotenv.get("mailosaurApiKey");
-
-    // Instantiate Mailosaur client with api key
-    MailosaurClient mailosaur = new MailosaurClient(apiKey);
+    MailosaurClient mailosaur = new MailosaurClient(dotenv.get("MAILOSAUR_API_KEY"));
 
     /**
      * This is a base32-encoded shared secret.

--- a/selenium/java/src/test/java/demo/OtpEmailTest.java
+++ b/selenium/java/src/test/java/demo/OtpEmailTest.java
@@ -2,12 +2,12 @@ package demo;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-import io.github.cdimascio.dotenv.Dotenv;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import io.github.cdimascio.dotenv.Dotenv;
 import com.mailosaur.MailosaurClient;
 import com.mailosaur.MailosaurException;
 import com.mailosaur.models.*;
@@ -20,13 +20,10 @@ public class OtpEmailTest {
     options.addArguments("--headless=new");
     WebDriver browser = new ChromeDriver(options);
 
-    Dotenv dotenv = Dotenv.load();
+    Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+    String serverId = dotenv.get("MAILOSAUR_SERVER_ID");
 
-    String apiKey = dotenv.get("mailosaurApiKey");
-    String serverId = dotenv.get("mailosaurServerId");    
-
-    // Instantiate Mailosaur client with api key
-    MailosaurClient mailosaur = new MailosaurClient(apiKey);
+    MailosaurClient mailosaur = new MailosaurClient(dotenv.get("MAILOSAUR_API_KEY"));
 
     // Random test email address (this uses a catch-all pattern)
     String randomString = UUID.randomUUID().toString().replaceAll("-", "").substring(7, 13);

--- a/selenium/java/src/test/java/demo/OtpSmsTest.java
+++ b/selenium/java/src/test/java/demo/OtpSmsTest.java
@@ -16,16 +16,13 @@ import java.io.IOException;
 public class OtpSmsTest {
   @Ignore("Reason")
   @Test public void retrieveOneTimePasscode() throws IOException, MailosaurException {
-    Dotenv dotenv = Dotenv.load();
+    Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+    String serverId = dotenv.get("MAILOSAUR_SERVER_ID");
 
-    String apiKey = dotenv.get("mailosaurApiKey");
-    String serverId = dotenv.get("mailosaurServerId"); 
+    // Add your Mailosaur phone number to this variable
+    String phoneNumber = dotenv.get("MAILOSAUR_PHONE_NUMBER");
 
-    // Add your mailosaur servers number to this variable
-    String phoneNumber = dotenv.get("mailosaurPhoneNumber");   
-
-    // Instantiate Mailosaur client with api key
-    MailosaurClient mailosaur = new MailosaurClient(apiKey);
+    MailosaurClient mailosaur = new MailosaurClient(dotenv.get("MAILOSAUR_API_KEY"));
 
     // 1 - Perform an action that sends an otp SMS message to your number
     // https://mailosaur.com/docs/sms-testing

--- a/selenium/java/src/test/java/demo/PasswordResetTest.java
+++ b/selenium/java/src/test/java/demo/PasswordResetTest.java
@@ -2,13 +2,13 @@ package demo;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-import io.github.cdimascio.dotenv.Dotenv;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import io.github.cdimascio.dotenv.Dotenv;
 import com.mailosaur.MailosaurClient;
 import com.mailosaur.MailosaurException;
 import com.mailosaur.models.*;
@@ -21,13 +21,10 @@ public class PasswordResetTest {
     options.addArguments("--headless=new");
     WebDriver browser = new ChromeDriver(options);
 
-    Dotenv dotenv = Dotenv.load();
+    Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+    String serverId = dotenv.get("MAILOSAUR_SERVER_ID");
 
-    String apiKey = dotenv.get("mailosaurApiKey");
-    String serverId = dotenv.get("mailosaurServerId");    
-
-    // Instantiate Mailosaur client with api key
-    MailosaurClient mailosaur = new MailosaurClient(apiKey);
+    MailosaurClient mailosaur = new MailosaurClient(dotenv.get("MAILOSAUR_API_KEY"));
 
     // Random test email address (this uses a catch-all pattern)
     String randomString = UUID.randomUUID().toString().replaceAll("-", "").substring(7, 13);

--- a/selenium/python/README.md
+++ b/selenium/python/README.md
@@ -45,7 +45,7 @@ MAILOSAUR_SERVER_ID=your-server-id
 MAILOSAUR_PHONE_NUMBER=your-mailosaur-phone-number
 ```
 
-You can find your API key and server ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can find your API key and inbox (server) ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
 
 ## Running Tests
 

--- a/selenium/python/README.md
+++ b/selenium/python/README.md
@@ -45,7 +45,7 @@ MAILOSAUR_SERVER_ID=your-server-id
 MAILOSAUR_PHONE_NUMBER=your-mailosaur-phone-number
 ```
 
-You can find your API key and inbox (server) ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+You can [find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). Your [inbox (server) ID](https://mailosaur.com/app/servers) is the first part of the inbox's domain (e.g. `abc123` in `abc123.mailosaur.net`).
 
 ## Running Tests
 

--- a/selenium/python/README.md
+++ b/selenium/python/README.md
@@ -16,6 +16,37 @@ We also have specific documentation for [Selenium](https://mailosaur.com/docs/fr
 
 As well as documentation for [Python](https://mailosaur.com/docs/languages/python).
 
+## Setup
+
+Install the project dependencies:
+
+```sh
+pip install -r requirements.txt
+```
+
+The Mailosaur client reads your API key from the `MAILOSAUR_API_KEY` environment variable, so you must export it before running the tests:
+
+```sh
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+```
+
+The SMS test (`test_otpSms.py`) additionally requires a Mailosaur phone number:
+
+```sh
+export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
+```
+
+These tests use [python-dotenv](https://pypi.org/project/python-dotenv/), so you can alternatively place the variables in a `.env` file in the project root:
+
+```
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=your-server-id
+MAILOSAUR_PHONE_NUMBER=your-mailosaur-phone-number
+```
+
+You can find your API key and server ID in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api).
+
 ## Running Tests
 
 You can run all the example tests included in this project using `python`:
@@ -72,7 +103,7 @@ python -m unittest test/test_otpSms.py
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` environment variable to your dedicated Mailosaur phone number — see the [Setup](#setup) section.)
 
 2. Grabs the one-time password (OTP).
 

--- a/selenium/python/test/test_otpAuthenticator.py
+++ b/selenium/python/test/test_otpAuthenticator.py
@@ -1,7 +1,6 @@
 # IMPORTANT: This test uses Mailosaur Authenticator, which may not
 # be enabled on your account yet (see https://mailosaur.com/app/devices)
 
-import os
 import unittest
 
 from dotenv import load_dotenv
@@ -14,10 +13,8 @@ class OtpAuthenticator(unittest.TestCase):
   @unittest.skip("reason")
   def test_generate_one_time_passcode(self):
 
-    api_key = os.getenv('MAILOSAUR_API_KEY')
-
-    # Instantiate Mailosaur client with api key
-    mailosaur = MailosaurClient(api_key)
+    # Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+    mailosaur = MailosaurClient()
 
     # This is a base32-encoded shared secret.
     # Typically this is the value shown to a user if they cannot scan an on-screen QR code.

--- a/selenium/python/test/test_otpEmail.py
+++ b/selenium/python/test/test_otpEmail.py
@@ -19,11 +19,10 @@ class OtpEmailTests(unittest.TestCase):
     options.add_argument("--headless=new")
     browser = webdriver.Chrome(options=options)
 
-    api_key = os.getenv('MAILOSAUR_API_KEY')
     server_id = os.getenv('MAILOSAUR_SERVER_ID')
 
-    # Instantiate Mailosaur client with api key
-    mailosaur = MailosaurClient(api_key)
+    # Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+    mailosaur = MailosaurClient()
 
     # Random test email address (this uses a catch-all pattern)
     random_string = base64.b32encode(secrets.token_bytes(8)).decode('utf-8')[6:]

--- a/selenium/python/test/test_otpSms.py
+++ b/selenium/python/test/test_otpSms.py
@@ -15,14 +15,13 @@ class OtpSmsTests(unittest.TestCase):
   @unittest.skip("reason")
   def test_retrieve_one_time_passcode(self):
 
-    api_key = os.getenv('MAILOSAUR_API_KEY')
     server_id = os.getenv('MAILOSAUR_SERVER_ID')
-    
+
     # Add your mailosaur servers number to this variable
     phone_number = os.getenv('MAILOSAUR_PHONE_NUMBER')
 
-    # Instantiate Mailosaur client with api key
-    mailosaur = MailosaurClient(api_key)
+    # Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+    mailosaur = MailosaurClient()
 
     # 1 - Perform an action that sends an otp SMS message to your number
     # https://mailosaur.com/docs/sms-testing

--- a/selenium/python/test/test_passwordReset.py
+++ b/selenium/python/test/test_passwordReset.py
@@ -19,11 +19,10 @@ class PasswordResetTests(unittest.TestCase):
     options.add_argument("--headless=new")
     browser = webdriver.Chrome(options=options)
 
-    api_key = os.getenv('MAILOSAUR_API_KEY')
     server_id = os.getenv('MAILOSAUR_SERVER_ID')
 
-    # Instantiate Mailosaur client with api key
-    mailosaur = MailosaurClient(api_key)
+    # Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from environment)
+    mailosaur = MailosaurClient()
 
     # Random test email address (this uses a catch-all pattern)
     random_string = base64.b32encode(secrets.token_bytes(8)).decode('utf-8')[6:]

--- a/selenium/ruby/README.md
+++ b/selenium/ruby/README.md
@@ -26,7 +26,7 @@ bundle install
 
 These tests rely on the following environment variables. You can export them in your shell, or place them in a `.env` file at the root of this sub-project (the `Rakefile` loads `.env` automatically via [dotenv](https://rubygems.org/gems/dotenv)):
 
-- `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The Mailosaur client reads this automatically.
+- `MAILOSAUR_API_KEY` — your Mailosaur API key. [Find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys). The Mailosaur client reads this automatically.
 - `MAILOSAUR_SERVER_ID` — the ID of the inbox (server) you want to send test emails to (used by `password_reset_spec.rb`, `otp_email_spec.rb`, and `otp_sms_spec.rb`).
 - `MAILOSAUR_PHONE_NUMBER` — a Mailosaur phone number, in international format (used by `otp_sms_spec.rb` only). [Enable SMS testing](https://mailosaur.com/app/sms) on your account first.
 

--- a/selenium/ruby/README.md
+++ b/selenium/ruby/README.md
@@ -16,6 +16,28 @@ We also have specific documentation for [Selenium](https://mailosaur.com/docs/fr
 
 As well as documentation for [Ruby](https://mailosaur.com/docs/languages/ruby).
 
+## Setup
+
+Before running the tests, install the project dependencies:
+
+```
+bundle install
+```
+
+These tests rely on the following environment variables. You can export them in your shell, or place them in a `.env` file at the root of this sub-project (the `Rakefile` loads `.env` automatically via [dotenv](https://rubygems.org/gems/dotenv)):
+
+- `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The Mailosaur client reads this automatically.
+- `MAILOSAUR_SERVER_ID` — the ID of the server you want to send test emails to (used by `password_reset_spec.rb`, `otp_email_spec.rb`, and `otp_sms_spec.rb`).
+- `MAILOSAUR_PHONE_NUMBER` — a Mailosaur phone number, in international format (used by `otp_sms_spec.rb` only). [Enable SMS testing](https://mailosaur.com/app/sms) on your account first.
+
+Example `.env`:
+
+```
+MAILOSAUR_API_KEY=your-api-key-here
+MAILOSAUR_SERVER_ID=abc123
+MAILOSAUR_PHONE_NUMBER=441234567890
+```
+
 ## Running Tests
 
 You can run all the example tests included in this project using `rake`:
@@ -72,7 +94,7 @@ rake spec SPEC=spec/otp_sms_spec.rb
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** You must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
 
 2. Grabs the one-time password (OTP).
 

--- a/selenium/ruby/README.md
+++ b/selenium/ruby/README.md
@@ -27,7 +27,7 @@ bundle install
 These tests rely on the following environment variables. You can export them in your shell, or place them in a `.env` file at the root of this sub-project (the `Rakefile` loads `.env` automatically via [dotenv](https://rubygems.org/gems/dotenv)):
 
 - `MAILOSAUR_API_KEY` — your Mailosaur API key. Find it in the [Mailosaur Dashboard](https://mailosaur.com/app/project/api). The Mailosaur client reads this automatically.
-- `MAILOSAUR_SERVER_ID` — the ID of the server you want to send test emails to (used by `password_reset_spec.rb`, `otp_email_spec.rb`, and `otp_sms_spec.rb`).
+- `MAILOSAUR_SERVER_ID` — the ID of the inbox (server) you want to send test emails to (used by `password_reset_spec.rb`, `otp_email_spec.rb`, and `otp_sms_spec.rb`).
 - `MAILOSAUR_PHONE_NUMBER` — a Mailosaur phone number, in international format (used by `otp_sms_spec.rb` only). [Enable SMS testing](https://mailosaur.com/app/sms) on your account first.
 
 Example `.env`:

--- a/selenium/ruby/spec/otp_authenticator_spec.rb
+++ b/selenium/ruby/spec/otp_authenticator_spec.rb
@@ -7,10 +7,8 @@ require 'mailosaur'
 
 RSpec.describe 'Otp authenticator' do
   before do
-    api_key = ENV['MAILOSAUR_API_KEY']
-
-    # Instantiate Mailosaur client with api key
-    @mailosaur = Mailosaur::MailosaurClient.new(api_key)
+    # Reads the API key from the MAILOSAUR_API_KEY environment variable
+    @mailosaur = Mailosaur::MailosaurClient.new
   end
 
   it 'Generate a one time passcode', skip: true do

--- a/selenium/ruby/spec/otp_email_spec.rb
+++ b/selenium/ruby/spec/otp_email_spec.rb
@@ -5,14 +5,13 @@ require 'selenium-webdriver'
 
 RSpec.describe 'Otp email' do
   before do
-    api_key = ENV['MAILOSAUR_API_KEY']
     @server_id = ENV['MAILOSAUR_SERVER_ID']
 
     options = Selenium::WebDriver::Options.chrome(args: ['--headless=new'])
     @browser = Selenium::WebDriver.for :chrome, options: options
 
-    # Instantiate Mailosaur client with api key
-    @mailosaur = Mailosaur::MailosaurClient.new(api_key)
+    # Reads the API key from the MAILOSAUR_API_KEY environment variable
+    @mailosaur = Mailosaur::MailosaurClient.new
   end
 
   it 'Retrieves a one time passcode' do

--- a/selenium/ruby/spec/otp_sms_spec.rb
+++ b/selenium/ruby/spec/otp_sms_spec.rb
@@ -7,14 +7,13 @@ require 'mailosaur'
 
 RSpec.describe 'Otp sms' do
   before do
-    api_key = ENV['MAILOSAUR_API_KEY']
     @server_id = ENV['MAILOSAUR_SERVER_ID']
 
     # Add your mailosaur servers number to this variable
     @phone_number = ENV['MAILOSAUR_PHONE_NUMBER']
 
-    # Instantiate Mailosaur client with api key
-    @mailosaur = Mailosaur::MailosaurClient.new(api_key)
+    # Reads the API key from the MAILOSAUR_API_KEY environment variable
+    @mailosaur = Mailosaur::MailosaurClient.new
   end
 
   it 'Retrieves a one time passcode', skip: true do

--- a/selenium/ruby/spec/password_reset_spec.rb
+++ b/selenium/ruby/spec/password_reset_spec.rb
@@ -5,14 +5,13 @@ require 'selenium-webdriver'
 
 RSpec.describe 'Password reset' do
   before do
-    api_key = ENV['MAILOSAUR_API_KEY']
     @server_id = ENV['MAILOSAUR_SERVER_ID']
 
     options = Selenium::WebDriver::Options.chrome(args: ['--headless=new'])
     @browser = Selenium::WebDriver.for :chrome, options: options
 
-    # Instantiate Mailosaur client with api key
-    @mailosaur = Mailosaur::MailosaurClient.new(api_key)
+    # Reads the API key from the MAILOSAUR_API_KEY environment variable
+    @mailosaur = Mailosaur::MailosaurClient.new
   end
 
   it 'Performs a password reset' do

--- a/webdriverio/README.md
+++ b/webdriverio/README.md
@@ -12,9 +12,28 @@ Visit [Mailosaur's website](https://mailosaur.com) to learn more about Mailosaur
 
 Documentation can be found on [Mailosaur's site](https://mailosaur.com/docs).
 
-We also have specific documentation for [WebdriverIO](https://mailosaur.com/docs/frameworks-and-tools/webdriverio).
+We also have specific documentation for [WebdriverIO](https://mailosaur.com/docs/frameworks-and-tools/webdriverio), as well as for [Node.js](https://mailosaur.com/docs/languages/nodejs).
 
-As well as documentation for [Node.js](https://mailosaur.com/docs/languages/nodejs).
+## Setup
+
+Install dependencies:
+
+```
+npm install
+```
+
+Set the following environment variables before running the tests. You can either `export` them in your shell, or place them in a `.env` file in this directory (the test specs load `.env` automatically via `dotenv`):
+
+- `MAILOSAUR_API_KEY` (required) — Your Mailosaur API key. [Find this in the Dashboard](https://mailosaur.com/app/project/api).
+- `MAILOSAUR_SERVER_ID` (required) — The ID of the Mailosaur server to use for the email-based tests.
+- `MAILOSAUR_PHONE_NUMBER` (optional) — Only required by `otpSms.js`. Set this to a phone number reserved on your Mailosaur account.
+
+```sh
+export MAILOSAUR_API_KEY='your-api-key-here'
+export MAILOSAUR_SERVER_ID='your-server-id'
+# Only needed for the SMS example:
+export MAILOSAUR_PHONE_NUMBER='your-mailosaur-phone-number'
+```
 
 ## Running Tests
 
@@ -24,7 +43,7 @@ You can run all the example tests included in this project using `npm`:
 npm run test
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Where a test depends on a feature that may not yet be enabled on your account, the test is skipped by default.
 
 # What's Included
@@ -72,7 +91,7 @@ npx wdio run ./wdio.conf.js --spec test/specs/otpSms.js
 
 When you run the test, it:
 
-1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (🚨 **NOTE:** Your must first set the `MAILOSAUR_PHONE_NUMBER` variable inside the `.env` file to your dedicated Mailosaur phone number.)
+1. Uses the Mailosaur API to wait for an SMS message to arrive at the given phone number. (Set the `MAILOSAUR_PHONE_NUMBER` environment variable to your dedicated Mailosaur phone number first — see [Setup](#setup).)
 
 2. Grabs the one-time password (OTP).
 

--- a/webdriverio/README.md
+++ b/webdriverio/README.md
@@ -24,7 +24,7 @@ npm install
 
 Set the following environment variables before running the tests. You can either `export` them in your shell, or place them in a `.env` file in this directory (the test specs load `.env` automatically via `dotenv`):
 
-- `MAILOSAUR_API_KEY` (required) — Your Mailosaur API key. [Find this in the Dashboard](https://mailosaur.com/app/project/api).
+- `MAILOSAUR_API_KEY` (required) — Your Mailosaur API key. [Find your API key in the Mailosaur Dashboard](https://mailosaur.com/app/keys).
 - `MAILOSAUR_SERVER_ID` (required) — The ID of the Mailosaur inbox (server) to use for the email-based tests.
 - `MAILOSAUR_PHONE_NUMBER` (optional) — Only required by `otpSms.js`. Set this to a phone number reserved on your Mailosaur account.
 

--- a/webdriverio/README.md
+++ b/webdriverio/README.md
@@ -25,7 +25,7 @@ npm install
 Set the following environment variables before running the tests. You can either `export` them in your shell, or place them in a `.env` file in this directory (the test specs load `.env` automatically via `dotenv`):
 
 - `MAILOSAUR_API_KEY` (required) — Your Mailosaur API key. [Find this in the Dashboard](https://mailosaur.com/app/project/api).
-- `MAILOSAUR_SERVER_ID` (required) — The ID of the Mailosaur server to use for the email-based tests.
+- `MAILOSAUR_SERVER_ID` (required) — The ID of the Mailosaur inbox (server) to use for the email-based tests.
 - `MAILOSAUR_PHONE_NUMBER` (optional) — Only required by `otpSms.js`. Set this to a phone number reserved on your Mailosaur account.
 
 ```sh

--- a/webdriverio/test/specs/otpAuthenticator.js
+++ b/webdriverio/test/specs/otpAuthenticator.js
@@ -8,8 +8,8 @@ dotenv.config();
 
 import MailosaurClient from 'mailosaur';
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+const mailosaur = new MailosaurClient();
 
 describe('One time passcode - Authenticator', () => {
   it.skip('generates a one time passcode', async () => {

--- a/webdriverio/test/specs/otpEmail.js
+++ b/webdriverio/test/specs/otpEmail.js
@@ -4,8 +4,8 @@ dotenv.config();
 import MailosaurClient from 'mailosaur';
 import { expect, browser, $ } from '@wdio/globals';
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+const mailosaur = new MailosaurClient();
 
 describe('One time passcode - Email', () => {
   it('retrieves a one time passcode', async () => {

--- a/webdriverio/test/specs/otpSms.js
+++ b/webdriverio/test/specs/otpSms.js
@@ -8,8 +8,8 @@ dotenv.config();
 
 import MailosaurClient from 'mailosaur';
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+const mailosaur = new MailosaurClient();
 
 describe('One time passcode - SMS', () => {
   it.skip('retrieves a one time passcode', async () => {

--- a/webdriverio/test/specs/passwordReset.js
+++ b/webdriverio/test/specs/passwordReset.js
@@ -4,8 +4,8 @@ dotenv.config();
 import MailosaurClient from 'mailosaur';
 import { expect, browser, $ } from '@wdio/globals';
 
-// Instantiate Mailosaur client with api key
-const mailosaur = new MailosaurClient(process.env.MAILOSAUR_API_KEY);
+// Instantiate Mailosaur client (reads MAILOSAUR_API_KEY from the environment)
+const mailosaur = new MailosaurClient();
 
 describe('Password reset', () => {
   it('performs a password reset', async () => {


### PR DESCRIPTION
## Summary

- Minor updates across the example projects.
- Adopt **inbox (server)** terminology in the README prose, so the documentation matches what users see in the dashboard.
- Update dashboard links for the new layout: API keys → `/app/keys`; the inbox (server) ID/domain → `/app/servers` (the ID is the first label of the inbox's domain). Removes the obsolete `/app/project/api` links.

## Scope

- Documentation only. Environment-variable instructions (`MAILOSAUR_SERVER_ID`) are unchanged.
